### PR TITLE
docs: add uv installation instructions

### DIFF
--- a/README
+++ b/README
@@ -28,10 +28,27 @@ Options
 
 
 Installation
-In command line, as root for system wide installation, or as user for a local installation
-pip install .
+
+Method 1: Using uv (Recommended)
+
+uv is a fast Python package and project manager. This is the recommended installation method as it handles dependencies automatically.
+
+Install as a tool (globally available):
+    uv tool install --with ujson --with PyQt6 git+https://github.com/papoteur-mga/elograf
+
+For development installation from local directory:
+    uv pip install --with ujson --with PyQt6 .
+
+Note: nerd-dictation is not included and needs to be installed separately.
+
+Method 2: Using pip
+
+In command line, as root for system wide installation, or as user for a local installation:
+    pip install .
+
 In case of local installation, be sure that ~/.local/bin is in the PATH variable.
 nerd-dictation is not included and needs to be installed separately.
+
 Python modules requirements:
 - ujson
 - urllib


### PR DESCRIPTION
## Summary

- Add recommended installation method using `uv` package manager
- Keep existing `pip` installation method as alternative
- Provide both global tool installation and local development options

## Changes

This PR adds installation instructions for using `uv`, a fast Python package and project manager, as the recommended installation method. The existing `pip` installation method is preserved as "Method 2".

The new instructions include:
- Global installation using `uv tool install`
- Local/development installation using `uv pip install`
- Clear note that nerd-dictation must be installed separately

## Benefits

- Simplifies dependency management with automatic handling of ujson and PyQt6
- Provides a modern installation alternative
- Maintains backward compatibility with existing pip-based workflow